### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,27 +1,30 @@
-v.133120 - 2013-11-08
-    Properly parse negative decimals
+Revision history for Perl module JavaScript::HashRef::Decode
 
-v.130240 - 2013-01-24
-    Add improved backslash decoding and support all backslash sequences
-    Faster string parsing, support \u notation
-    Support more decimal and hex number syntaxes
-    Requires perl 5.10.0
+0.133120 2013-11-08
+    - Properly parse negative decimals
 
-v.130220 - 2013-01-22
-    Die properly on invalid input (#1 on github)
-    Add link to ECMAScript spec
+0.130240 2013-01-24
+    - Add improved backslash decoding and support all backslash sequences
+    - Faster string parsing, support \u notation
+    - Support more decimal and hex number syntaxes
+    - Requires perl 5.10.0
 
-v.130160 - 2013-01-16
-    Fix test failure on 5.8.9 (defined-or)
+0.130220 2013-01-22
+    - Die properly on invalid input (#1 on github)
+    - Add link to ECMAScript spec
 
-v.130142 - 2013-01-14
-    Add support for true, false, null
-    hashref keys can be single- and double- quoted strings
-    Renamed key_value to tuple
-    Added description
+0.130160 2013-01-16
+    - Fix test failure on 5.8.9 (defined-or)
 
-v.130141 - 2013-01-14
-    Fixed POD
+0.130142 2013-01-14
+    - Add support for true, false, null
+    - hashref keys can be single- and double- quoted strings
+    - Renamed key_value to tuple
+    - Added description
 
-v.130140 - 2013-01-14
-    Initial release
+0.130141 2013-01-14
+    - Fixed POD
+
+0.130140 2013-01-14
+    - Initial release
+


### PR DESCRIPTION
Hi Marco,

I made some changes to your Changes file, so it will conform to CPAN::Changes::Spec
- Added header line identifying the file
- Release header line starts with version, without leading 'v'
- no '-' between version and date
- Made changes into bullet list

Following this format means that various tools can more easily process your distribution automatically. For example MetaCPAN will then display the most recent changes on [your dist's page](https://metacpan.org/release/MFONTANI/JavaScript-HashRef-Decode-0.133120), which it doesn't now because it can't parse the file (compare with [Module-Path](https://metacpan.org/release/Module-Path), where it can parse the file, for example).

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
